### PR TITLE
create dockerfile just for mongo

### DIFF
--- a/Dockerfile.mongo
+++ b/Dockerfile.mongo
@@ -1,0 +1,23 @@
+FROM python:3.8-slim as base
+
+FROM base as builder
+# Any python libraries that require system libraries to be installed will likely
+# need the following packages in order to build
+RUN apt-get update && apt-get install -y build-essential git
+
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+ARG install_dev_dependencies=true
+
+WORKDIR /app
+
+# Install stac_fastapi.types
+COPY . /app
+
+ENV PATH=$PATH:/install/bin
+
+RUN mkdir -p /install && \
+    pip install -e ./stac_fastapi/types[dev] && \
+    pip install -e ./stac_fastapi/api[dev] && \
+    pip install -e ./stac_fastapi/extensions[dev] && \
+    pip install -e ./stac_fastapi/mongo[dev,server]

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -7,13 +7,14 @@ services:
     restart: always
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.mongo
     platform: linux/amd64
     environment:
       - APP_HOST=0.0.0.0
       - APP_PORT=8083
       - RELOAD=false
       - ENVIRONMENT=local
+      - WEB_CONCURRENCY=10
       - MONGO_USER=dev
       - MONGO_PASS=stac
       - MONGO_PORT=27017


### PR DESCRIPTION
**Related Issue(s):** #


**Description:**
Add dockerfile for mongo, add web concurrency env variable back in

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).