### PR TITLE
Fix connection with database in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - MONGO_USER=dev
       - MONGO_PASS=stac
       - MONGO_PORT=27017
-      - MONGO_HOST=172.17.0.1
+      - MONGO_HOST=mongo_db
     ports:
       - "8083:8083"
     volumes:


### PR DESCRIPTION
**Related Issue(s):** #


**Description:**
The api can not connect to mongo db when usong docker compose because the mongo host is wrong

**PR Checklist:**

- [v] Code is formatted and linted (run `pre-commit run --all-files`)
- [v] Tests pass (run `make test`)
- [v] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).